### PR TITLE
Add the os section to the .travis.yml for testing on both OSX and Linux

### DIFF
--- a/lib/App/Mi6/Template.pm6
+++ b/lib/App/Mi6/Template.pm6
@@ -13,6 +13,9 @@ gitignore => qq:to/EOF/,
 EOF
 
 travis => qq:to/EOF/,
+os:
+  - linux
+  - osx
 language: perl6
 perl6:
   - latest


### PR DESCRIPTION
Hi
I have added the os section to the .travis.yml for testing on both OSX and Linux.
