### PR TITLE
Fix commit message for bumping version

### DIFF
--- a/lib/App/Mi6/Release/GitCommit.pm6
+++ b/lib/App/Mi6/Release/GitCommit.pm6
@@ -7,7 +7,7 @@ method run(*%opt) {
         return;
     }
 
-    my $message = %opt<next-version>;
+    my $message = "Bump version to " ~ %opt<next-version>;
     my $proc;
     $proc = run <git commit -a -m>, $message;
     die if $proc.exitcode != 0;


### PR DESCRIPTION
I believe that "Bump version to `<version>`" is better than "`<version>`" because the former is less ambiguous.