### PR TITLE
Fix version requirement in META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -9,7 +9,7 @@
     "JSON::Pretty",
     "Pod::To::Markdown",
     "Shell::Command",
-    "CPAN::Uploader::Tiny:ver(v0.0.4 .. *)"
+    "CPAN::Uploader::Tiny:ver(0.0.4+)"
   ],
   "description" : "minimal authoring tool for Perl6",
   "license" : "Artistic-2.0",


### PR DESCRIPTION
The :ver needs to be a version literal "0.0.4+" as Version will parse it.