### PR TITLE
Restrict to concrete versions only

### DIFF
--- a/lib/App/Mi6.pm6
+++ b/lib/App/Mi6.pm6
@@ -255,8 +255,8 @@ method make-dist-tarball($main-module) {
     my $name = $main-module.subst("::", "-", :g);
     my $meta = App::Mi6::JSON.decode("META6.json".IO.slurp);
     my $version = $meta<version>;
-    die "To make dist tarball, you must specify version (not '*') in META6.json first"
-        if $version eq '*';
+    die "To make dist tarball, you must specify a concrete version (no '*' or '+') in META6.json first"
+        if $version.contains('*') or $version.ends-with('+');
     $name ~= "-$version";
     rm_rf $name if $name.IO.d;
     unlink "$name.tar.gz" if "$name.tar.gz".IO.e;


### PR DESCRIPTION
Disallow `0.*` and `0.0+` style version ranges when declaring the version for what something -is- ( as opposed to what something -wants- like `"perl" : "6.*"` which is ok ).