### PR TITLE
use git-remote-origin

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -35,7 +35,7 @@
     "App::Mi6::Util" : "lib/App/Mi6/Util.pm6"
   },
   "resources" : [ ],
-  "source-url" : "git://github.com/skaji/mi6.git",
+  "source-url" : "https://github.com/skaji/mi6.git",
   "tags" : [ ],
   "test-depends" : [
     "File::Temp"

--- a/lib/App/Mi6.pm6
+++ b/lib/App/Mi6.pm6
@@ -287,8 +287,8 @@ sub find-source-url() {
     my @line = run("git", "remote", "-v", :out, :!err).out.lines(:close);
     return "" unless @line;
     my $url = gather for @line -> $line {
-        my ($, $url) = $line.split(/\s+/);
-        if $url {
+        my ($name, $url) = $line.split(/\s+/);
+        if $name eq "origin" and $url {
             take $url;
             last;
         }


### PR DESCRIPTION
Use "origin" by default. cf #60