### PR TITLE
Support .t6 files in test directories

### DIFF
--- a/lib/App/Mi6.pm6
+++ b/lib/App/Mi6.pm6
@@ -113,6 +113,8 @@ sub build() {
 sub test(@file, Bool :$verbose, Int :$jobs) {
     withp6lib {
         my @option = "-r";
+        @option.push("--ext", ".t");
+        @option.push("--ext", ".t6");
         @option.push("-v") if $verbose;
         @option.push("-j", $jobs) if $jobs;
         if @file.elems == 0 {

--- a/xt/01-actual.t
+++ b/xt/01-actual.t
@@ -35,6 +35,12 @@ my $tempdir = tempdir;
     $r = mi6 "test";
     isnt $r.exit, 0;
     like $r.out, rx/Failed/;
+
+    # Check .t6 extension
+    "xt/01-fail.t".IO.rename("xt/01-fail.t6");
+    $r = mi6 "test";
+    isnt $r.exit, 0;
+    like $r.out, rx/Failed/;
 }
 {
     temp $*CWD = $tempdir.IO;


### PR DESCRIPTION
This allows Mi6 to support tests with a .t6 extension in addition to the traditional .t extension.

This is related to https://github.com/perl6/user-experience/issues/36