### PR TITLE
Convert to using TAP::Harness

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -8,7 +8,8 @@
     "JSON::Pretty",
     "Pod::To::Markdown:ver<0.1.4+>",
     "Shell::Command",
-    "CPAN::Uploader::Tiny:ver<0.0.4+>"
+    "CPAN::Uploader::Tiny:ver<0.0.4+>",
+    "TAP:ver<0.0.8+>"
   ],
   "description" : "minimal authoring tool for Raku",
   "license" : "Artistic-2.0",


### PR DESCRIPTION
Currently mi6 is using `prove` for testing, thus hard depending on perl5. This patch will make it use the perl6 test harness instead.