### PR TITLE
Only read the "dist.ini" once

### DIFF
--- a/lib/App/Mi6.pm6
+++ b/lib/App/Mi6.pm6
@@ -25,7 +25,7 @@ my $to-file = -> $module {
 };
 
 my sub config($section, $key?, :$default = Any) {
-    my $top = "dist.ini".IO.e ?? App::Mi6::INI::parsefile("dist.ini") !! {};
+    state $top = "dist.ini".IO.e ?? App::Mi6::INI::parsefile("dist.ini") !! {};
     my $config = $top{$section};
     return $config || $default if !$config || !$key;
     my $pair = @($config).grep({ $_.key eq $key }).first;


### PR DESCRIPTION
Since we're going to check for more flags in the dist.ini config, it feels we should be reading this only once, instead of every time we call "config".