### PR TITLE
add Badge class

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -17,6 +17,7 @@
   "perl" : "6.c",
   "provides" : {
     "App::Mi6" : "lib/App/Mi6.pm6",
+    "App::Mi6::Badge" : "lib/App/Mi6/Badge.pm6",
     "App::Mi6::INI" : "lib/App/Mi6/INI.pm6",
     "App::Mi6::JSON" : "lib/App/Mi6/JSON.pm6",
     "App::Mi6::Release" : "lib/App/Mi6/Release.pm6",

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Actions Status](https://github.com/skaji/mi6/workflows/linux/badge.svg)](https://github.com/skaji/mi6/actions)
+
 NAME
 ====
 
@@ -62,6 +64,13 @@ name = Your-Module-Name
 [MetaNoIndex]
 ; if you do not want to list some files in META6.json as "provides", then
 ; filename = lib/Should/Not/List/Provides.pm6
+
+[Badges]
+; if you want to add badges to README.md, then
+; provider = travis-ci.org
+; provider = travis-ci.com
+; provider = appveyor
+; provider = github-actions/name
 ```
 
 How can I manage depends, build-depends, test-depends?

--- a/dist.ini
+++ b/dist.ini
@@ -5,3 +5,6 @@ filename = lib/App/Mi6.pm6
 
 [PruneFiles]
 match = ^ 'xt/'
+
+[Badges]
+provider = github-actions/linux

--- a/lib/App/Mi6/Badge.pm6
+++ b/lib/App/Mi6/Badge.pm6
@@ -1,0 +1,32 @@
+use v6.c;
+unit class App::Mi6::Badge;
+
+has $.provider is required;
+has $.user is required;
+has $.repo is required;
+has $.name;
+
+my %markdown =
+    "travis-ci.org" => -> :$user, :$repo, :$name {
+        "[![Build Status](https://travis-ci.org/$user/$repo.svg?branch=master)]"
+        ~ "(https://travis-ci.org/$user/$repo)";
+    },
+    "travis-ci.com" => -> :$user, :$repo, :$name {
+        "[![Build Status](https://travis-ci.com/$user/$repo.svg?branch=master)]"
+        ~ "(https://travis-ci.com/$user/$repo)";
+    },
+    "appveyor" => -> :$user, :$repo, :$name {
+        "[![Windows Status](https://ci.appveyor.com/api/projects/status/github/$user/$repo?branch=master&passingText=Windows%20-%20OK&failingText=Windows%20-%20FAIL&pendingText=Windows%20-%20pending&svg=true)]"
+        ~ "(https://ci.appveyor.com/project/$user/$repo/branch/master)";
+    },
+    "github-actions" => -> :$user, :$repo, :$name {
+        "[![Actions Status](https://github.com/$user/$repo/workflows/$name/badge.svg)]"
+        ~ "(https://github.com/$user/$repo/actions)";
+    },
+;
+
+method markdown(--> Str) {
+    my $markdown = %markdown{$!provider};
+    die "invalid badge type $!provider" if !$markdown;
+    $markdown(:$!user, :$!repo, :$!name);
+}

--- a/xt/02-badge.t
+++ b/xt/02-badge.t
@@ -1,0 +1,19 @@
+use v6.c;
+use Test;
+
+use App::Mi6::Badge;
+
+my $user = "user";
+my $repo = "repo";
+my $name = "test";
+
+my $m1 = App::Mi6::Badge.new(provider => "travis-ci.org", :$user, :$repo, :$name).markdown();
+is $m1, '[![Build Status](https://travis-ci.org/user/repo.svg?branch=master)](https://travis-ci.org/user/repo)';
+my $m2 = App::Mi6::Badge.new(provider => "travis-ci.com", :$user, :$repo, :$name).markdown();
+is $m2, '[![Build Status](https://travis-ci.com/user/repo.svg?branch=master)](https://travis-ci.com/user/repo)';
+my $m3 = App::Mi6::Badge.new(provider => "appveyor", :$user, :$repo, :$name).markdown();
+is $m3, '[![Windows Status](https://ci.appveyor.com/api/projects/status/github/user/repo?branch=master&passingText=Windows%20-%20OK&failingText=Windows%20-%20FAIL&pendingText=Windows%20-%20pending&svg=true)](https://ci.appveyor.com/project/user/repo/branch/master)';
+my $m4 = App::Mi6::Badge.new(provider => "github-actions", :$user, :$repo, :$name).markdown();
+is $m4, '[![Actions Status](https://github.com/user/repo/workflows/test/badge.svg)](https://github.com/user/repo/actions)';
+
+done-testing;


### PR DESCRIPTION
This PR introduces a generic Badge class.

Now you can generate badges for travis-ci.org,  travis-ci.com, appveyor and github-actions with the following config:

```ini
[Badges]
provider = travis-ci.org
provider = travis-ci.com
provider = appveyor
provider = github-actions/name
```