### PR TITLE
Default TravisCI Badge breaks the code

### DIFF
--- a/lib/App/Mi6.pm6
+++ b/lib/App/Mi6.pm6
@@ -156,7 +156,7 @@ method readme-header() {
     return "" if !$user;
     my $badges = config("Badges", default => []);
     if @$badges == 0 && ".travis.yml".IO.e {
-        push $badges, (badge =>"travis-ci.org");
+        push $badges, (provider =>"travis-ci.org");
     }
     return "" if @$badges == 0;
 


### PR DESCRIPTION
When I execute following command I can see an error. I think is the case because the default for travis ci is not added correctly. Not 100% sure, tough.

```
> mi6 test
unknown key Badges.badge in dist.ini
  in method readme-header at C:\rakudo\share\perl6\site\sources\CAB9D7446C73886FE83EF8A1522AAD640CB76214 (App::Mi6) line 165
  in method regenerate-readme at C:\rakudo\share\perl6\site\sources\CAB9D7446C73886FE83EF8A1522AAD640CB76214 (App::Mi6) line 189
  in method cmd at C:\rakudo\share\perl6\site\sources\CAB9D7446C73886FE83EF8A1522AAD640CB76214 (App::Mi6) line 75
  in method cmd at C:\rakudo\share\perl6\site\sources\CAB9D7446C73886FE83EF8A1522AAD640CB76214 (App::Mi6) line 81
  in sub MAIN at C:\rakudo\share\perl6\site\resources\7C4D38244022050CCF759D85134D522344850EF8 line 18
  in block <unit> at C:\rakudo\share\perl6\site\resources\7C4D38244022050CCF759D85134D522344850EF8 line 6
  in sub MAIN at C:\rakudo\share\perl6\site\bin\mi6 line 3
  in block <unit> at C:\rakudo\share\perl6\site\bin\mi6 line 1
```