### PR TITLE
Add support for modules using OO::Monitors

### DIFF
--- a/lib/App/Mi6/Release/BumpVersion.rakumod
+++ b/lib/App/Mi6/Release/BumpVersion.rakumod
@@ -9,7 +9,7 @@ my $PACKAGE-LINE = rx/
     ^
     $<before>=(
         \s* 'unit'? \s*
-        ['module'|'class'|'grammar'|'role']
+        ['module'|'class'|'grammar'|'role'|'monitor']
         \s+
         [ <[a..zA..Z0..9_-]> | '::' ]+
         .*


### PR DESCRIPTION
The [OO::Monitors](https://github.com/jnthn/oo-monitors) library adds a `monitor` keyword to define classes whose methods should only ever be accessed by one thread at a time.

This change makes it so that `mi6` can successfully identify classes using this keyword.