### PR TITLE
introduce UploadToZef

### DIFF
--- a/bin/mi6
+++ b/bin/mi6
@@ -7,8 +7,8 @@ my $app = App::Mi6.new;
 multi MAIN("version") {
     say $app.^ver;
 }
-multi MAIN("new", $module) {
-    $app.cmd("new", $module);
+multi MAIN("new", $module, :fez(:$zef)) {
+    $app.cmd("new", $module, :$zef);
 }
 multi MAIN("build") {
     $app.cmd("build");
@@ -19,7 +19,7 @@ multi MAIN("test", *@file, Bool :v(:$verbose), Int :j(:$jobs)) {
 multi MAIN("release", Bool :k(:$keep), Str :$next-version, Bool :$yes) {
     $app.cmd("release", :$keep, :$next-version, :$yes);
 }
-multi MAIN("dist") {
+multi MAIN("dist", Bool :$no-top-directory) {
     $app.cmd("dist");
 }
 multi MAIN("upload") {
@@ -54,7 +54,7 @@ sub USAGE {
     Create Foo-Bar distribution
 
     Options:
-     (none)
+      --fez, --zef  create distribution for Zef ecosystem
 
   $ mi6 build
     Build the distribution, and re-generate README.md/META6.json.

--- a/lib/App/Mi6/Fez.rakumod
+++ b/lib/App/Mi6/Fez.rakumod
@@ -1,0 +1,12 @@
+unit class App::Mi6::Fez;
+
+use Fez::Util::Config;
+use App::Mi6::Util;
+
+method username() {
+    config-value('un');
+}
+
+method upload($tarball) {
+    mi6run "fez", "--file=$tarball", "upload";
+}

--- a/lib/App/Mi6/Release.rakumod
+++ b/lib/App/Mi6/Release.rakumod
@@ -1,22 +1,30 @@
 unit class App::Mi6::Release;
 
-my @klass =
-    CheckChanges => "Make sure 'Changes' file has the next release description",
-    CheckOrigin => "",
-    CheckUntrackedFiles => "",
-    BumpVersion => "Bump version for modules (eg: 0.0.1 -> 0.0.2)",
-    RegenerateFiles => "",
-    DistTest => "",
-    MakeDist => "",
-    UploadToCPAN => "Upload tarball to CPAN!",
-    RewriteChanges => "",
-    GitCommit => "Git commit, and push it to remote",
-    CreateGitTag => "Create git tag, and push it to remote",
-    CleanDist => "",
-;
+
+has $.upload-class = "UploadToCPAN";
+
+method !classes() {
+    my @klass =
+        CheckChanges => "Make sure 'Changes' file has the next release description",
+        CheckOrigin => "",
+        CheckUntrackedFiles => "",
+        BumpVersion => "Bump version for modules (eg: 0.0.1 -> 0.0.2)",
+        RegenerateFiles => "",
+        DistTest => "",
+        MakeDist => "",
+        $.upload-class => "",
+        RewriteChanges => "",
+        GitCommit => "Git commit, and push it to remote",
+        CreateGitTag => "Create git tag, and push it to remote",
+        CleanDist => "",
+    ;
+    return @klass;
+}
 
 method !desc {
-    note "==> Release distribution to CPAN";
+    my @klass = self!classes;
+    my $where = $.upload-class eq "UploadToZef" ?? "Zef ecosystem" !! "CPAN ecosystem";
+    note "==> Release distribution to $where";
     note "";
     note "  There are {+@klass} steps:";
     for @klass.kv -> $i, $pair {
@@ -30,6 +38,8 @@ method run(*%opt is copy) {
     self!desc;
     my &color = $*DISTRO.is-win || %*ENV<NO_COLOR> ?? ({$_}) !! ({"\e[32;1m$_\e[m"});
     my $prefix = "App::Mi6::Release::";
+
+    my @klass = self!classes;
     for @klass.kv -> $i, $pair {
         my $klass = $pair.key;
         my $full-klass = $prefix ~ $klass;

--- a/lib/App/Mi6/Release/UploadToZef.rakumod
+++ b/lib/App/Mi6/Release/UploadToZef.rakumod
@@ -1,0 +1,26 @@
+unit class App::Mi6::Release::UploadToZef;
+
+use App::Mi6::Util;
+use App::Mi6::Fez;
+
+method run(*%opt) {
+    if %*ENV<FAKE_RELEASE> {
+        note "Skip UploadToZef because FAKE_RELEASE is set.";
+        return;
+    }
+    my $tarball = %opt<tarball>;
+    if !%opt<yes> {
+        loop {
+            my $answer = prompt("Are you sure you want to upload $tarball to Zef ecosystem? (y/N)");
+            if $answer ~~ rx:i/^y(es)?$/ {
+                last;
+            } elsif $answer ~~ rx:i/^n(o)?$/ {
+                die "Abort.\n";
+            } else {
+                say "Please type Yes or No.";
+            }
+        };
+    }
+    note "===> Uploading $tarball to Zef ecosystem";
+    App::Mi6::Fez.upload($tarball);
+}

--- a/lib/App/Mi6/Template.rakumod
+++ b/lib/App/Mi6/Template.rakumod
@@ -1,6 +1,6 @@
 unit module App::Mi6::Template;
 
-our sub template(:$module, :$module-file, :$dist, :$author, :$cpanid, :$email, :$year) {
+our sub template(:$module, :$module-file, :$dist, :$author, :$auth, :$email, :$year) {
     my %template =
 
 Changes => qq:to/EOF/,
@@ -16,6 +16,8 @@ name = $dist
 [ReadmeFromPod]
 ; enable = false
 filename = $module-file
+
+[UploadTo{ $auth && $auth ~~ /^zef:/ ?? "Zef" !! "CPAN" }]
 
 [PruneFiles]
 ; match = ^ 'xt/'
@@ -74,7 +76,7 @@ done-testing;
 END_OF_TEST
 
 module => qq:to/EOD_OF_MODULE/,
-unit class $module\:ver<0.0.1>{ $cpanid ?? ":auth<cpan:$cpanid>" !! ""};
+unit class $module\:ver<0.0.1>{ $auth ?? ":auth<$auth>" !! ""};
 
 
 =begin pod


### PR DESCRIPTION
This PR introduces UploadToZef step for `mi6 release`,
which releases your distribution to Zef (Fez) ecosystem instead of CPAN (PAUSE).

To use UploadToZef, set `[UploadToZef]` in dist.int:

```ini
name = Foo-Bar

[UploadToZef]
```

and execute `mi6 release`:

```
❯ mi6 release
==> Release distribution to Zef ecosystem

  There are 12 steps:
   * Step 1. CheckChanges - Make sure 'Changes' file has the next release description
   * Step 2. CheckOrigin
   * Step 3. CheckUntrackedFiles
   * Step 4. BumpVersion - Bump version for modules (eg: 0.0.1 -> 0.0.2)
   * Step 5. RegenerateFiles
   * Step 6. DistTest
   * Step 7. MakeDist
   * Step 8. UploadToZef
   * Step 9. RewriteChanges
   * Step10. GitCommit - Git commit, and push it to remote
   * Step11. CreateGitTag - Create git tag, and push it to remote
   * Step12. CleanDist
 ...
 ```