### PR TITLE
Add possibility to disable automatic version / auth

### DIFF
--- a/lib/App/Mi6.rakumod
+++ b/lib/App/Mi6.rakumod
@@ -238,13 +238,17 @@ method regenerate-meta-info($module, $module-file) {
     $perl = "6.d" if $perl eq "v6";
     $perl ~~ s/^v//;
 
-    my $version = do {
+    my $version = config("VersionInMeta").defined
+      ?? $already<version>
+      !! do {
         my @cmd = $*EXECUTABLE, "-M$module", "-e", "$module.^ver.Str.say";
         my $p = with-rakulib { mi6run |@cmd, :out, :!err };
         my $v = $p.out.slurp(:close).chomp || $already<version>;
         $v eq "*" ?? "0.0.1" !! $v;
     };
-    my $auth = do {
+    my $auth = config("AuthInMeta").defined
+      ?? $already<auth>
+      !! do {
         my @cmd = $*EXECUTABLE, "-M$module", "-e", "$module.^auth.Str.say";
         my $p = with-rakulib { mi6run |@cmd, :out, :!err };
         $p.out.slurp(:close).chomp || $already<auth> || Nil;

--- a/lib/App/Mi6/Release/BumpVersion.rakumod
+++ b/lib/App/Mi6/Release/BumpVersion.rakumod
@@ -77,7 +77,9 @@ method scan($dir) {
 }
 
 method current-version {
-    @!line.map(*<version>).sort({ Version.new($^b) <=> Version.new($^a) }).first;
+    @!line.map(*<version>).sort(*.Version).first
+      // (run <git tag -l>, :out).out.lines(:close).sort(*.Version).tail
+      // "0.0.1"
 }
 
 method next-version($version? is copy) {


### PR DESCRIPTION
By default, App::Mi6 automatically adapts the META6.JSON from
information obtained from the main source file (specifically
the :ver<> and :auth<> information).  This is great in general!

However, some modules that just export a single subroutine
shouldn't even need a "class", "module" or "package" statement.
But even worse, if the name of the distribution is the same as
the sub being exported, the logic that App::Mi6 uses, will always
set the version of the module to "6.c".  This is because of the
following behaviour:

    say sub { }.^ver;  # 6.c

App::Mi6 basically runs the following one-liner:

    $ raku -I. -Mmodule -e 'say Module.^ver'

which in the case of an actuall class, module or package, *does*
do the right thing.  But in the case of e.g. the "eigenstates"
distribution:

    $ raku -I. -Meigenstates -e 'say eigenstates.^ver'

the "eigenstates" refers to the exported "&eigenstates", and
thus to put "6.c" as the version in the META.  For an example
of this:

https://github.com/lizmat/uniname-words/blob/d2641d1c97e1dee2dd512818b310d2e6b21a2cef/META6.json#L24

This adds the capability to switch off automatic versioning
and automatic auth setting by specifying [VersionInMeta] and/or
[AuthInMeta] in the dist.ini file.  This gives the author
complete control by making what is in META6.json leading.

This also needed some changes in the "Bump Release" logic,
which now will attempt to find the highest tag instead.