### PR TITLE
retrieve ver/auth from META6.json

### DIFF
--- a/lib/App/Mi6/Template.rakumod
+++ b/lib/App/Mi6/Template.rakumod
@@ -3,6 +3,13 @@ unit module App::Mi6::Template;
 our sub template(:$module, :$module-file, :$dist, :$author, :$auth, :$email, :$year) {
     my %template =
 
+META6 => qq:to/EOF/,
+\{
+    { $auth ?? qq["auth": "$auth",] !! ""}
+    "version": "0.0.1"
+\}
+EOF
+
 Changes => qq:to/EOF/,
 Revision history for $dist
 
@@ -76,7 +83,7 @@ done-testing;
 END_OF_TEST
 
 module => qq:to/EOD_OF_MODULE/,
-unit class $module\:ver<0.0.1>{ $auth ?? ":auth<$auth>" !! ""};
+unit class $module;
 
 
 =begin pod


### PR DESCRIPTION
## Context

Currently, mi6 assumes that `ver` and `auth` are specified in Module.rakumod
as `class Module:ver<0.0.1>:auth<cpan:SKAJI>`.

I thought this was useful and a good practice
because end-users could inspect Module's ver and auth by `Module.^ver` and `Module.^auth`.

But it turned out that it was just *confusing*.

The most common situation where end-users pay attention to Module's ver and auth is to "use" Module, i.e.,

```
use Module:ver<X>:auth<Y>;
```

Surprisingly `ver<X>` and `auth<Y>` here are NOT specification for Module,
but rather for the distribution defined in META6.json.

In the end, I think we should declare version and auth only in META6.json, not in Module.rakumod.

## Changes

This PR makes mi6 retrieve ver/auth from META6.json, not from Module.rakumod.

Note that people still can specify ver and auth in Module.rakumod if they want, and mi6 will bump ver while releasing distributions.

It just means mi6 will treat version and auth in META6.json as the *primary* information.

This PR will close #129 
This PR will also close #126 