### PR TITLE
introduce dist() method

### DIFF
--- a/lib/App/Mi6.rakumod
+++ b/lib/App/Mi6.rakumod
@@ -10,7 +10,14 @@ use TAP;
 
 BEGIN { $*PERL.compiler.version >= v2020.05 or die "App::Mi6 needs rakudo v2020.05 or later" }
 
-unit class App::Mi6:ver<1.1.5>:auth<cpan:SKAJI>;
+unit class App::Mi6;
+
+# You can inspect App-Mi6 distribution by this dist() method. For example,
+#
+#   say App::Mi6.dist.meta<version>; # 1.1.5
+#   say App::Mi6.dist.meta<auth>;    # cpan:SKAJI
+#
+method dist() { $?DISTRIBUTION }
 
 my $MODULE-EXT = / '.' [ pm | pm6 | rakumod ] /;
 


### PR DESCRIPTION
This PR removes ver and auth from `class App::Mi6:ver<1.1.5>:auth<cpan:SKAJI>`.
Instead, it introduces a new method `dist()` which actually returns `$?DISTRIBUTION`
so that people inspect App-Mi6 distribution as they want.

For example, people can get version and auth by

```raku
use App::Mi6;

say App::Mi6.dist.meta<version>; # 1.1.5
say App::Mi6.dist.meta<auth>;    # cpan:SKAJI
```