### PR TITLE
require rakudo v2020.11 or later

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           # - windows-latest # disabled for now
         raku-version:
           - 'latest'
-          - '2020.05.1'
+          - '2020.11'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ mi6 release  # release your distribution to CPAN/Zef ecosystem (configured by 
 INSTALLATION
 ============
 
-First make sure you have rakudo v2020.05 or later. If not, install rakudo from [https://rakudo.org/downloads](https://rakudo.org/downloads).
+First make sure you have rakudo v2020.11 or later. If not, install rakudo from [https://rakudo.org/downloads](https://rakudo.org/downloads).
 
 Then:
 

--- a/lib/App/Mi6.rakumod
+++ b/lib/App/Mi6.rakumod
@@ -8,7 +8,7 @@ use CPAN::Uploader::Tiny;
 use Shell::Command;
 use TAP;
 
-BEGIN { $*PERL.compiler.version >= v2020.05 or die "App::Mi6 needs rakudo v2020.05 or later" }
+BEGIN { $*RAKU.compiler.version >= v2020.11 or die "App::Mi6 needs rakudo v2020.11 or later" }
 
 unit class App::Mi6;
 


### PR DESCRIPTION
Now a dependency TAP requires rakudo v2020.11.

In fact, it does not work on rakudo v2020.10:
```
❯ raku -v
Welcome to 𝐑𝐚𝐤𝐮𝐝𝐨™ v2020.10.
Implementing the 𝐑𝐚𝐤𝐮™ programming language v6.d.
Built on MoarVM version 2020.10.

❯ raku -Ilib -MTAP -e 'say 1'
===SORRY!=== Error while compiling -e
===SORRY!=== Error while compiling /home/skaji/src/github.com/Raku/tap-harness6/lib/TAP.pm (TAP)
Coercion 'IO(Str)' is insufficiently type-like to qualify a variable.
Did you mean 'class'?
at /home/skaji/src/github.com/Raku/tap-harness6/lib/TAP.pm (TAP):800
------>    has IO(Str) $.filename handles<slurp>⏏;
    expecting any of:
        constraint

at -e:1
```

Let's bump rakudo dependency for mi6 too.