### PR TITLE
Don't *change* the "provides" section on build

### DIFF
--- a/lib/App/Mi6.rakumod
+++ b/lib/App/Mi6.rakumod
@@ -266,7 +266,7 @@ method regenerate-meta($module, $module-file) {
         test-depends  => $already<test-depends> || [],
         build-depends => $already<build-depends> || [],
         description   => find-description($module-file) || $already<description> || "",
-        provides      => self.find-provides(),
+        provides      => $already<provides> || self.find-provides(),
         source-url    => $already<source-url> || find-source-url(),
         resources     => $already<resources> || [],
         tags          => $already<tags> || [],

--- a/lib/App/Mi6.rakumod
+++ b/lib/App/Mi6.rakumod
@@ -266,7 +266,9 @@ method regenerate-meta($module, $module-file) {
         test-depends  => $already<test-depends> || [],
         build-depends => $already<build-depends> || [],
         description   => find-description($module-file) || $already<description> || "",
-        provides      => $already<provides> || self.find-provides(),
+        provides      => config("DontTouchProvides").defined
+                           ?? ($already<provides> || self.find-provides())
+                           !! self.find-provides(),
         source-url    => $already<source-url> || find-source-url(),
         resources     => $already<resources> || [],
         tags          => $already<tags> || [],

--- a/xt/01-actual.rakutest
+++ b/xt/01-actual.rakutest
@@ -98,9 +98,6 @@ my $tempdir = tempdir;
     EOF
     run "git", "add", ".";
 
-    "META6.json".IO.spurt:
-      "META6.json".IO.slurp.subst: / '  "provides": {' <( <-[}]>+ /;
-
     mi6 "build";
     my $meta = App::Mi6::JSON.decode( "META6.json".IO.slurp );
     is $meta<provides>, {

--- a/xt/01-actual.rakutest
+++ b/xt/01-actual.rakutest
@@ -98,6 +98,9 @@ my $tempdir = tempdir;
     EOF
     run "git", "add", ".";
 
+    "META6.json".IO.spurt:
+      "META6.json".IO.slurp.subst: / '  "provides": {' <( <-[}]>+ /;
+
     mi6 "build";
     my $meta = App::Mi6::JSON.decode( "META6.json".IO.slurp );
     is $meta<provides>, {


### PR DESCRIPTION
Currently, App::Mi6 on a build or test action, will remake the
"provides" section of META6.json into a replica of the file-structure
in "lib".  This can be both incorrect and unneeded.  For instance,
more than one use target can point to the same source file.  Or have
a different mapping, e.g. to handle unicode issues in filenames.

Therefore, App::Mi6 should not touch the "provides" section after
the initial build.

Case in point is my rework of the DateTime::TimeZone module.  In
the old situation, each timezone (even linked to another one) would
have its own source file.  In the new situation, linked timezones
are listed in their "parent" timezone class, and the META6.json
ensures that that loading a linked timezone class will load its
"parent" timezone, and thus provide the correct class.  This
reduces the number of files that need to be precompiled by about
one hundred.

All timezone source files as well as the META6.json are generated
from the Olson timezone database.  App::Mi6's actions on META6.json
currently overwrites the carefully crafted mappings :-(