### PR TITLE
Test from dot

### DIFF
--- a/lib/App/Mi6.rakumod
+++ b/lib/App/Mi6.rakumod
@@ -266,7 +266,7 @@ method regenerate-meta($module, $module-file) {
         test-depends  => $already<test-depends> || [],
         build-depends => $already<build-depends> || [],
         description   => find-description($module-file) || $already<description> || "",
-        provides      => self.find-provides(),
+        provides      => $already<provides> || self.find-provides(),
         source-url    => $already<source-url> || find-source-url(),
         resources     => $already<resources> || [],
         tags          => $already<tags> || [],

--- a/lib/App/Mi6.rakumod
+++ b/lib/App/Mi6.rakumod
@@ -208,7 +208,7 @@ multi list-testfiles(IO::Path $path) {
 }
 
 sub test(@file, Bool :$verbose, Int :$jobs) {
-    my %args = handlers => TAP::Harness::SourceHandler::Raku.new(incdirs => ["lib"]);
+    my %args = handlers => TAP::Harness::SourceHandler::Raku.new(incdirs => ["."]);
     %args<jobs> = $jobs with $jobs;
     %args<volume> = TAP::Verbose with $verbose;
     if @file.elems == 0 {


### PR DESCRIPTION
Tests should be performed with `-I.` rather than `-Ilib`, because the `META6.json` of the distribution *must* be used to get the use target mapping to source-file.  Using `-Ilib` will ignore anything in the `META6.json`, which may be incorrect.