### PR TITLE
update github action badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Actions Status](https://github.com/skaji/mi6/workflows/test/badge.svg)](https://github.com/skaji/mi6/actions)
+[![Actions Status](https://github.com/skaji/mi6/actions/workflows/test.yml/badge.svg)](https://github.com/skaji/mi6/actions)
 
 NAME
 ====

--- a/dist.ini
+++ b/dist.ini
@@ -7,4 +7,4 @@ filename = lib/App/Mi6.rakumod
 match = ^ 'xt/'
 
 [Badges]
-provider = github-actions/test
+provider = github-actions/test.yml

--- a/lib/App/Mi6/Badge.rakumod
+++ b/lib/App/Mi6/Badge.rakumod
@@ -19,8 +19,13 @@ my %markdown =
         ~ "(https://ci.appveyor.com/project/$user/$repo/branch/master)";
     },
     "github-actions" => -> :$user, :$repo, :$name {
-        "[![Actions Status](https://github.com/$user/$repo/workflows/$name/badge.svg)]"
-        ~ "(https://github.com/$user/$repo/actions)";
+        if $name ~~ / [yml || yaml ] $/ {
+            "[![Actions Status](https://github.com/$user/$repo/actions/workflows/$name/badge.svg)]"
+            ~ "(https://github.com/$user/$repo/actions)";
+        } else {
+            "[![Actions Status](https://github.com/$user/$repo/workflows/$name/badge.svg)]"
+            ~ "(https://github.com/$user/$repo/actions)";
+        }
     },
 ;
 

--- a/lib/App/Mi6/Template.rakumod
+++ b/lib/App/Mi6/Template.rakumod
@@ -23,7 +23,7 @@ filename = $module-file
 ; match = ^ 'xt/'
 
 [Badges]
-provider = github-actions/test
+provider = github-actions/test.yml
 EOF
 
 workflow => q:to/EOF/,

--- a/xt/02-badge.rakutest
+++ b/xt/02-badge.rakutest
@@ -14,5 +14,9 @@ my $m3 = App::Mi6::Badge.new(provider => "appveyor", :$user, :$repo, :$name).mar
 is $m3, '[![Windows Status](https://ci.appveyor.com/api/projects/status/github/user/repo?branch=master&passingText=Windows%20-%20OK&failingText=Windows%20-%20FAIL&pendingText=Windows%20-%20pending&svg=true)](https://ci.appveyor.com/project/user/repo/branch/master)';
 my $m4 = App::Mi6::Badge.new(provider => "github-actions", :$user, :$repo, :$name).markdown();
 is $m4, '[![Actions Status](https://github.com/user/repo/workflows/test/badge.svg)](https://github.com/user/repo/actions)';
+my $m5 = App::Mi6::Badge.new(provider => "github-actions", :$user, :$repo, :name<test.yml>).markdown();
+is $m5, '[![Actions Status](https://github.com/user/repo/actions/workflows/test.yml/badge.svg)](https://github.com/user/repo/actions)';
+my $m6 = App::Mi6::Badge.new(provider => "github-actions", :$user, :$repo, :name<test.yaml>).markdown();
+is $m6, '[![Actions Status](https://github.com/user/repo/actions/workflows/test.yaml/badge.svg)](https://github.com/user/repo/actions)';
 
 done-testing;


### PR DESCRIPTION
I don't know when, but at some point, github changed the badge url. This PR follows it.
https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge