### PR TITLE
introduce RunBeforeBuild and RunAfterBuild

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -36,6 +36,7 @@
     "App::Mi6::Release::RewriteChanges": "lib/App/Mi6/Release/RewriteChanges.rakumod",
     "App::Mi6::Release::UploadToCPAN": "lib/App/Mi6/Release/UploadToCPAN.rakumod",
     "App::Mi6::Release::UploadToZef": "lib/App/Mi6/Release/UploadToZef.rakumod",
+    "App::Mi6::Run": "lib/App/Mi6/Run.rakumod",
     "App::Mi6::Template": "lib/App/Mi6/Template.rakumod",
     "App::Mi6::Util": "lib/App/Mi6/Util.rakumod"
   },

--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ name = Your-Module-Name
 ; provider = travis-ci.com
 ; provider = appveyor
 ; provider = github-actions/name.yml
+
+; execute some commands before `mi6 build`
+[RunBeforeBuild]
+; %x will be replaced by $*EXECUTABLE
+; cmd = %x -e 'say "hello"'
+; cmd = %x -e 'say "world"'
+
+; execute some commands after `mi6 build`
+[RunAfterBuild]
+; cmd = some shell command here
 ```
 
 How can I manage depends, build-depends, test-depends?

--- a/lib/App/Mi6/Run.rakumod
+++ b/lib/App/Mi6/Run.rakumod
@@ -1,0 +1,15 @@
+unit class App::Mi6::Run;
+
+has $.raw-cmd;
+
+method cmd() {
+    my $cmd = $.raw-cmd;
+    $cmd .= subst('%x', $*EXECUTABLE);
+    $cmd;
+}
+
+method run() {
+    my $cmd = $.cmd();
+    my $proc = shell $cmd;
+    die "Failed to execute $cmd" if !?$proc;
+}

--- a/xt/01-actual.rakutest
+++ b/xt/01-actual.rakutest
@@ -141,4 +141,21 @@ my $tempdir = tempdir;
     is $r.exit, 0 or diag $r.err;
 }
 
+{
+    temp $*CWD = $tempdir.IO;
+    mi6 "new", "Build::Test3";
+    chdir "Build-Test3";
+    "dist.ini".IO.spurt: q:to/EOF/, :append;
+    [RunBeforeBuild]
+    cmd = %x -e 'print 1'
+    cmd = %x -e 'print 2'
+    [RunAfterBuild]
+    cmd = %x -e 'print 3'
+    cmd = %x -e 'print 4'
+    EOF
+    my $r = mi6 "build";
+    is $r.exit, 0 or diag $r.err;
+    like $r.out, rx/1234/;
+}
+
 done-testing;


### PR DESCRIPTION
This PR introduces "RunBeforeBuild" and "RunAfterBuild",
which allow us to execute some commands during `mi6 build`.

Here is an example:

```ini
; dist.ini
[RunAfterBuild]
; %x will be replaced by $*EXECUTABLE
cmd = %x -I. --doc=Markdown lib/Some/Module/AdditionalDoc.rakudoc > doc.md
cmd = some-linter-command
```

```
❯ mi6 build
==> RunAfterBuild: Execute /Users/skaji/env/rakuenv/versions/2022.07-01/bin/rakudo -I. --doc=Markdown lib/Some/Module/AdditionalDoc.rakudoc > doc.md
==> RunAfterBuild: Execute some-linter-command
...
```
