### PR TITLE
Add spacing configuration to dist.ini

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -47,5 +47,5 @@
   ],
   "test-depends": [
   ],
-  "version": "3.0.0"
+  "version": "3.1.0"
 }

--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ name = Your-Module-Name
 ; execute some commands after `mi6 build`
 [RunAfterBuild]
 ; cmd = some shell command here
+
+[MetaGeneration]
+; by default, META6.json is regenerated with 2 spaces indentation
+; if you want to modify that, you can set:
+; spacing = 4
 ```
 
 How can I manage depends, build-depends, test-depends?

--- a/lib/App/Mi6/JSON.rakumod
+++ b/lib/App/Mi6/JSON.rakumod
@@ -1,7 +1,7 @@
 unit class App::Mi6::JSON;
 
-method encode(::?CLASS:U: %hash) {
-    Rakudo::Internals::JSON.to-json: %hash, :pretty, :sorted-keys;
+method encode(::?CLASS:U: %hash, Int:D :$spacing = 2) {
+    Rakudo::Internals::JSON.to-json: %hash, :$spacing, :pretty, :sorted-keys;
 }
 
 method decode(::?CLASS:U: $string) {


### PR DESCRIPTION
Hello,

inspired by a complaint from [Coke] on the IRC, I made an option to change (re)indentation of META6.json from 2 spaces to some other amount of spaces which was already supported by the underlying JSON API.

Other than that, I made one little change: the config sub should rather return untyped `Nil` as the ultimate default than `Any` because `Any` would fail when trying to assign to a variable with a type annotation. With `Nil`, it will correctly set the corresponding type object.

It would also be really good to add a test case at least. I wasn't sure how to add tests that depend on some demo input file. If somebody can show me a good approach, I'd be willing to add a couple of test cases as a "gift". :P