### PR TITLE
remove git --global for correct name/email in multi-copyright envs

### DIFF
--- a/lib/App/Mi6.rakumod
+++ b/lib/App/Mi6.rakumod
@@ -43,9 +43,9 @@ my sub config($section, $key?, :$default = Any) {
     $pair ?? $pair.value !! $default;
 }
 
-method !author() { mi6run(<git config --global user.name>,  :out).out.slurp(:close).chomp }
+method !author() { mi6run(<git config user.name>,  :out).out.slurp(:close).chomp }
 
-method !email()  { mi6run(<git config --global user.email>, :out).out.slurp(:close).chomp }
+method !email()  { mi6run(<git config user.email>, :out).out.slurp(:close).chomp }
 
 method !cpan-user() {
     try require ::("CPAN::Uploader::Tiny");
@@ -66,7 +66,7 @@ multi method cmd('new', $module is copy, :$cpan) {
     my $module-dir = $module-file.IO.dirname.Str;
     mkpath($_) for $module-dir, "t", "bin", ".github/workflows";
 
-    note "Loading author's name and email from git config --global user.name / user.email";
+    note "Loading author's name and email from git config user.name / user.email";
     my $author = self!author;
     my $email = self!email;
 


### PR DESCRIPTION
In a mixed copyright development environment, ``git`` can be configured to use specific email/name details for different working directories.

As an example, this can be achieved with entries like:
```
# ~/.gitconfig
[includeIf "gitdir:~/src/jaguart/"]
    path = ~/src/jaguart/.gitconfig-include
```

And then personal details in ``src/jaguart`` can specify the correct name / email for personal projects.
```
# ~/src/jaguart/.gitconfig-include
[user]
        name = Jeff Armstrong
        email = jeff@jaguart.tech
        signingkey = ...
```
mi6 v3.0.0 uses the ``git --global`` flag, which subverts the intended git behaviour.

This small change simply removes the ``--global`` flag on the calls and thereby let's git determine the correct name / email for the current working directory.

Many thanks.



