### PR TITLE
Scaffolding - bundled and user-defined skeletons

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -41,6 +41,8 @@
     "App::Mi6::Util": "lib/App/Mi6/Util.rakumod"
   },
   "resources": [
+    "MIT/license",
+    "MIT/module"
   ],
   "source-url": "https://github.com/skaji/mi6.git",
   "tags": [

--- a/bin/mi6
+++ b/bin/mi6
@@ -7,8 +7,8 @@ my $app = App::Mi6.new;
 multi MAIN("version") {
     say $app.dist.meta<version>;
 }
-multi MAIN("new", $module, :fez(:$zef), :$cpan) {
-    $app.cmd("new", $module, :$cpan);
+multi MAIN("new", $module, :fez(:$zef), :$cpan, :$scaffold ) {
+    $app.cmd("new", $module, :$cpan, :$scaffold );
 }
 multi MAIN("build") {
     $app.cmd("build");
@@ -54,7 +54,16 @@ sub USAGE {
     Create Foo-Bar distribution
 
     Options:
-      --cpan  create distribution for CPAN ecosystem, instead of Zef ecosystem
+      --cpan      create distribution for CPAN ecosystem, instead of Zef ecosystem
+
+      --scaffold  Use specified scaffolding to create new project.
+
+                  If you specify a directory, the following optional files
+                  will be used to scaffold the varous parts of your new project:
+                    Changes dist module test license gitignore workflow
+
+                  You can alternately specify one of the following flavours:
+                    MIT - use the MIT license
 
   $ mi6 build
     Build the distribution, and re-generate README.md/META6.json.

--- a/lib/App/Mi6.rakumod
+++ b/lib/App/Mi6.rakumod
@@ -55,7 +55,7 @@ method !cpan-user() {
         !! Nil;
 }
 
-multi method cmd('new', $module is copy, :$cpan) {
+multi method cmd('new', $module is copy, :$cpan, :$scaffold ) {
     $module ~~ s:g/ '-' /::/;
     my $main-dir = $module;
     $main-dir ~~ s:g/ '::' /-/;
@@ -85,6 +85,14 @@ multi method cmd('new', $module is copy, :$cpan) {
         }
     }
 
+    # user specified skeleton / scaffolding
+    my %scaffold = App::Mi6::Template::external(
+        $scaffold,
+        :$module, :$author, :$auth, :$email,
+        :$module-file, :$ecosystem,
+        :year(Date.today.year),
+        :dist($module.subst("::", "-", :g)),
+    );
     my %content = App::Mi6::Template::template(
         :$module, :$author, :$auth, :$email,
         :$module-file, :$ecosystem,
@@ -101,7 +109,7 @@ multi method cmd('new', $module is copy, :$cpan) {
         .github/workflows/test.yml workflow
     >>;
     for %map.kv -> $f, $c {
-        spurt($f, %content{$c});
+        spurt($f, %scaffold{$c} || %content{$c});
     }
     my %meta =
         authors => [ $author ],

--- a/resources/MIT/license
+++ b/resources/MIT/license
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) $year $author
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/resources/MIT/module
+++ b/resources/MIT/module
@@ -1,0 +1,32 @@
+unit class $module;
+
+
+=begin pod
+
+=head1 NAME
+
+$module - blah blah blah
+
+=head1 SYNOPSIS
+
+=begin code :lang<raku>
+
+use $module;
+
+=end code
+
+=head1 DESCRIPTION
+
+$module is ...
+
+=head1 AUTHOR
+
+$author <$email>
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright $year $author
+
+This library is free software; you can redistribute it and/or modify it under the MIT License.
+
+=end pod

--- a/xt/01-actual.rakutest
+++ b/xt/01-actual.rakutest
@@ -157,4 +157,12 @@ my $tempdir = tempdir;
     like $r.out, rx/1234/;
 }
 
+{
+    temp $*CWD = $tempdir.IO;
+    mi6 "new", "Build::Test4", "--scaffold=MIT";
+    chdir "Build-Test4";
+    like "LICENSE".IO.slurp, rx/MIT\sLicense/;
+    unlike "README.md".IO.slurp, rx/Apache/;
+}
+
 done-testing;


### PR DESCRIPTION
Please consider this pull request as **_only a suggestion_** - I have added two simple scaffolding options:

1. ``--scaffold=~/.my-raku-scaffolding/`` - ``mi6`` will use files in this directory to scaffold, if they are present: ``Changes dist module test license gitignore workflow``
2. ``--scaffold=MIT`` - ``mi6`` will scaffold using the files in ``resources/MIT`` - I have just made one example with the MIT license.

I have only created one simple test, and have not verified it on Windows. If you would like any changes, I am happy to assist where I can. My Raku is only a few months old.

If you would prefer to delete this pull request - that is fine too, I appreciate that you may have your own plans. In any case, thank you for ``mi6`` - it helps me a lot.
