### PR TITLE
use --no-xattrs option when creating tarball in macos

### DIFF
--- a/lib/App/Mi6/Release/MakeDist.rakumod
+++ b/lib/App/Mi6/Release/MakeDist.rakumod
@@ -26,15 +26,7 @@ method run(*%opt) {
             );
         }
     }
-    my %env = %*ENV;
-    %env<$_> = 1 for <COPY_EXTENDED_ATTRIBUTES_DISABLE COPYFILE_DISABLE>;
-    my $proc = mi6run "tar", "czf", "$name.tar.gz", $name, :!out, :err, :%env;
-    LEAVE $proc && $proc.err.close;
-    if $proc.exitcode != 0 {
-        my $exitcode = $proc.exitcode;
-        my $err = $proc.err.slurp;
-        die $err ?? $err !! "can't create tarball, exitcode = $exitcode";
-    }
+    my $tarball = make-tarball($name);
     tarball => "$name.tar.gz";
 }
 

--- a/lib/App/Mi6/Util.rakumod
+++ b/lib/App/Mi6/Util.rakumod
@@ -18,3 +18,18 @@ sub with-rakulib($dir, &code) is export {
     %*ENV<RAKULIB> = %*ENV<RAKULIB>:exists ?? "$dir," ~ %*ENV<RAKULIB> !! $dir;
     &code();
 }
+
+sub make-tarball($dir) is export {
+    my @option = $*DISTRO eq "macos" ?? ("--no-xattrs") !! ();
+    my %env = %*ENV;
+    %env<COPY_EXTENDED_ATTRIBUTES_DISABLE> = "1";
+    %env<COPYFILE_DISABLE> = "1";
+    my $proc = mi6run "tar", |@option, "-czf", "$dir.tar.gz", $dir, :!out, :err, :%env;
+    LEAVE $proc && $proc.err.close;
+    if $proc.exitcode != 0 {
+        my $exitcode = $proc.exitcode;
+        my $err = $proc.err.slurp;
+        die $err ?? $err !! "can't create tarball, exitcode = $exitcode";
+    }
+    "$dir.tar.gz";
+}


### PR DESCRIPTION
Fix #166 

It seems that we need to use --no-xattrs option when creating tarball in macos.

Steps to reproduce:
```console
❯ mkdir test
❯ touch test/a.txt
❯ xattr -w feztest 1 test/a.txt

### case1: create test-1.tar.gz without --no-xattrs option
❯ env COPY_EXTENDED_ATTRIBUTES_DISABLE=1 COPYFILE_DISABLE=1 /usr/bin/tar -czf test-1.tar.gz test
❯ /bin/pax -c -z -f test-1.tar.gz
test
pax: Unrecognized header keyword: LIBARCHIVE.xattr.feztest
pax: Unrecognized header keyword: SCHILY.xattr.feztest
test/a.txt

### case2: create test-1.tar.gz with --no-xattrs option
❯ env COPY_EXTENDED_ATTRIBUTES_DISABLE=1 COPYFILE_DISABLE=1 /usr/bin/tar --no-xattrs -czf test-2.tar.gz test
❯ /bin/pax -c -z -f test-2.tar.gz
test
test/a.txt
```