### PR TITLE
matrix fail-fast

### DIFF
--- a/lib/App/Mi6/Template.rakumod
+++ b/lib/App/Mi6/Template.rakumod
@@ -36,6 +36,7 @@ on:
 jobs:
   raku:
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-latest


### PR DESCRIPTION
ensure in matrix strategy that e.g. failing windows runs do not cancel otherwise healthy ubuntu or macos runs