### PR TITLE
Install module instead of using prove6

### DIFF
--- a/lib/App/Mi6/Template.rakumod
+++ b/lib/App/Mi6/Template.rakumod
@@ -50,11 +50,9 @@ jobs:
         with:
           raku-version: ${{ matrix.raku-version }}
       - name: Install Dependencies
-        run: zef install --/test --test-depends --deps-only .
-      - name: Install App::Prove6
-        run: zef install --/test App::Prove6
-      - name: Run Tests
-        run: prove6 -I. t
+        run: zef --error --deps-only --fetch-degree=4 --/test --test-depends install .
+      - name: Install Module
+        run: zef --debug --/depends install .
 EOF
 
 gitignore => qq:to/EOF/,


### PR DESCRIPTION
Installing prove6 takes time and is a dependency perhaps not needed for fully automated testing inside a github workflow. Installing the module itself - like a user would do - achieves the same result and ensures that the module is "installable" by end users.