### PR TITLE
Tighten dependencies to latest/greatest and pin fez version

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -7,9 +7,9 @@
   ],
   "depends": [
     "Pod::To::Markdown:ver<0.2.1+>",
-    "Shell::Command",
-    "fez:ver<38+>",
-    "TAP:ver<0.3.8+>"
+    "Shell::Command:ver<1.2+>:auth<zef:raku-community-modules>",
+    "fez:ver<55>:auth<zef:tony-o>",
+    "TAP:ver<0.3.15+>:auth<zef:leont>"
   ],
   "description": "minimal authoring tool for Raku",
   "license": "Artistic-2.0",
@@ -43,7 +43,7 @@
   "resources": [
   ],
   "source-url": "https://github.com/skaji/mi6.git",
-  "tags": [
+  "tags": [ "AUTHORING", "ZEF", "CPAN", "PAUSE"
   ],
   "test-depends": [
   ],

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Shoichi Kaji <skaji@cpan.org>
 COPYRIGHT AND LICENSE
 =====================
 
-Copyright 2015 Shoichi Kaji
+Copyright 2015 - 2025 Shoichi Kaji
 
 This library is free software; you can redistribute it and/or modify it under the Artistic License 2.0.
 

--- a/lib/App/Mi6.rakumod
+++ b/lib/App/Mi6.rakumod
@@ -6,12 +6,13 @@ use App::Mi6::Release;
 use App::Mi6::Run;
 use App::Mi6::Template;
 use App::Mi6::Util;
-use Shell::Command;
-use TAP;
+
+use Shell::Command:ver<1.2+>:auth<zef:raku-community-modules>;
+use TAP:ver<0.3.15+>:auth<zef:leont>;
 
 BEGIN { $*RAKU.compiler.version >= v2020.11 or die "App::Mi6 needs rakudo v2020.11 or later" }
 
-unit class App::Mi6;
+unit class App::Mi6:ver<3.0.6>:auth<zef:skaji>;
 
 # You can inspect App-Mi6 distribution by this dist() method. For example,
 #
@@ -681,7 +682,7 @@ Shoichi Kaji <skaji@cpan.org>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2015 Shoichi Kaji
+Copyright 2015 - 2025 Shoichi Kaji
 
 This library is free software; you can redistribute it and/or modify it under the Artistic License 2.0.
 

--- a/lib/App/Mi6/Fez.rakumod
+++ b/lib/App/Mi6/Fez.rakumod
@@ -1,6 +1,6 @@
 unit class App::Mi6::Fez;
 
-use Fez::Util::Config;
+use Fez::Util::Config:ver<55>:auth<zef:tony-o>;
 use App::Mi6::Util;
 
 method user() {

--- a/lib/App/Mi6/Release/CleanDist.rakumod
+++ b/lib/App/Mi6/Release/CleanDist.rakumod
@@ -1,6 +1,6 @@
 unit class App::Mi6::Release::CleanDist;
 
-use Shell::Command;
+use Shell::Command:ver<1.2+>:auth<zef:raku-community-modules>;
 
 method run(*%opt) {
     return if %opt<keep>;

--- a/lib/App/Mi6/Release/MakeDist.rakumod
+++ b/lib/App/Mi6/Release/MakeDist.rakumod
@@ -1,5 +1,5 @@
 unit class App::Mi6::Release::MakeDist;
-use Shell::Command;
+use Shell::Command:ver<1.2+>:auth<zef:raku-community-modules>;
 use App::Mi6::JSON;
 use App::Mi6::Util;
 

--- a/lib/App/Mi6/Release/UploadToCPAN.rakumod
+++ b/lib/App/Mi6/Release/UploadToCPAN.rakumod
@@ -1,7 +1,7 @@
 unit class App::Mi6::Release::UploadToCPAN;
 
 no precompilation;
-use CPAN::Uploader::Tiny;
+use CPAN::Uploader::Tiny:ver<0.1.0+>:auth<zef:skaji>;
 use App::Mi6::Util;
 
 method run(*%opt) {


### PR DESCRIPTION
The latest version of fez has a slightly different API which *may* cause issues with App::Mi6.  It therefore felt safer to pin it to the last version prior to version 100 until it has been determined that there are no issues with the latest fez version.

Tightened up other dependencies, because that's a good thing to do in a world where accountability is becoming more important.

Also updated copyright year and added tags