### PR TITLE
Account for changes in .fez-config.json file

### DIFF
--- a/lib/App/Mi6/Fez.rakumod
+++ b/lib/App/Mi6/Fez.rakumod
@@ -9,7 +9,7 @@ method user() {
 
 method groups() {
     my $groups = config-value('groups') || [];
-    $groups.map({.<group>});
+    $groups.map({.<name> // .<group>})
 }
 
 method upload($tarball) {


### PR DESCRIPTION
It appears that the newer version of fez has changed the format of the .fez-config file with regards to groups, which made it impossible for people to do an upload for e.g. Raku Community modules.

Instead of:

    "groups": [
      {
        "group": "raku-community-modules",

the new format uses "name" as the key, instead of "group":

    "groups": [
      {
        "name": "raku-community-modules",

This commit fixes that by first checking for the new key ("name"), and if that didn't yield a result, try the old key ("group").

This also removes a warning about using undefined values for anybody that has a fez group membership of any kind.